### PR TITLE
WIP: docs(book): add api intro and database schema

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -12,7 +12,8 @@
     - [Database](./auth/database.md)
     - [API](./auth/api.md)
 
-- [API service]()
+- [API service](./api/index.md)
+    - [Database](./api/database.md)
     - [API]()
 
 - [Game server]()

--- a/docs/book/src/api/api.md
+++ b/docs/book/src/api/api.md
@@ -1,0 +1,305 @@
+# Introduction
+
+Since this and the authentication service are very similar, so is the
+documentation. Please read the [introduction of the authentication
+service](../auth/api.md#introduction) to better understand how this
+documentation is laid out.
+
+# Routes
+
+## POST to `/account`
+
+Updates personal information.
+
+### Input
+
+#### Headers
+
+- `Authorization: Bearer <token>`
+
+#### Data
+
+```admonish info
+Only not `undefined` values are updated, the rest stays the same.
+```
+
+```typescript
+interface Body {
+    /* This represents [this](../database.md#user_data). */
+    mature: boolean | undefined;
+}
+```
+
+### Output
+
+#### Error codes
+
+```admonish warning
+TBD stands for "to be determined" and means we need to determine a minimum age for which not to display mature content.
+```
+
+- `1` : mature is set to true and the age of the client is lower than TBD or undefined.
+
+#### HTTP codes
+
+- `400` : if the input is malformed (missing fields, unknown fields, etc.).
+- `401` : if no authorization token was provided or if the authorization token is invalid.
+
+## POST to `/friend/{name}`
+
+Send a friend request.
+
+### Input
+
+#### Headers
+
+- `Authorization: Bearer <token>`
+
+#### Data
+
+```typescript
+interface Url {
+    name: string; /* The name of the friend to add. */
+}
+```
+
+### Output
+
+#### Error codes
+
+- `1` : the name does not belong to any user.
+
+#### HTTP codes
+
+- `400` : if the input is malformed (missing fields, unknown fields, etc.).
+- `401` : if no authorization token was provided or if the authorization token is invalid.
+
+## PUT to `/friend`
+
+Accept a friend request.
+
+When a user sends a friend request, the API server generates a token, which
+contains the ID's of both users. It then encrypts it with it's private key. Upon
+acceptance of the request, the server decrypts the token, and if the users match
+the ones in the token, they become friends. Some might say that `name` in
+the accept request is not needed, but in fact, it is. Let me explain by giving
+you an example. Let's say I'm Alex, and I want to be friends with Bogdan, but
+Bogdan doesn't want to because I am unbearable, but Bogdan would be ok with
+being friends with Claire. Alex asks Claire to send Bogdan a friend request with
+his own token, so that when Bogdan accepts, Alex and Bogdan become friends. By
+sending the name along, we ensure that this trick did not happened.
+
+We also send an expiration date in order to avoid very old friend requests (+1
+months) to be accepted.
+
+```admonish info
+The public key is available to anyone. This way, the token can also be read by
+the browser.
+```
+
+### Input
+
+#### Headers
+
+- `Authorization: Bearer <token>`
+
+#### Data
+
+```typescript
+interface Body {
+    friendRequestToken: string;
+    expirationDate: number;
+}
+
+interface Url {
+    name: string;
+}
+```
+
+### Output
+
+#### Error codes
+
+- `1` : the users in the token does not match the users in the request.
+- `2` : expiration date has been reached.
+
+#### HTTP codes
+
+- `400` : if the input is malformed (missing fields, unknown fields, etc.).
+- `401` : if no authorization token was provided or if the authorization token is invalid.
+
+## `DELETE` to `/friend/{name}`
+
+Removes a friend from the friend list.
+
+### Input
+
+#### Headers
+
+- `Authorization: Bearer <token>`
+
+#### Data
+
+```typescript
+interface Url {
+    name: string;
+}
+```
+
+### Output
+
+#### Error codes
+
+- `1` : no user with this name was found.
+
+#### HTTP codes
+
+- `400` : if the input is malformed (missing fields, unknown fields, etc.).
+- `401` : if no authorization token was provided or if the authorization token is invalid.
+
+## `POST` to `/user/block/{name}`
+
+Block another user.
+
+### Input
+
+#### Headers
+
+- `Authorization: Bearer <token>`
+
+#### Data
+
+```typescript
+interface Url {
+    name: string;
+}
+```
+
+### Output
+
+#### Error codes
+
+- `1` : no user with this name was found.
+- `2` : user already blocked.
+
+#### HTTP codes
+
+- `400` : if the input is malformed (missing fields, unknown fields, etc.).
+- `401` : if no authorization token was provided or if the authorization token is invalid.
+
+## `DELETE` to `/user/block/{name}`
+
+Unblock a blocked user.
+
+### Input
+
+#### Headers
+
+- `Authorization: Bearer <token>`
+
+#### Data
+
+```typescript
+interface Url {
+    name: string;
+}
+```
+
+### Output
+
+#### Error codes
+
+- `1` : no user with this name was found.
+- `1` : user not blocked.
+
+#### HTTP codes
+
+- `400` : if the input is malformed (missing fields, unknown fields, etc.).
+- `401` : if no authorization token was provided or if the authorization token is invalid.
+
+## `GET` to `/user/{name}`
+
+Get the profile of a user.
+
+```admonish warning "Privacy"
+Do not allow people to get the profile if :
+
+- the requested user has blocked the requesting user.
+- the requested user has a private profile.
+```
+
+### Input
+
+#### Headers
+
+- `Authorization: Bearer <token>`
+
+#### Data
+
+```typescript
+interface Url {
+    name: string;
+}
+```
+
+### Output
+
+#### Data
+
+```admonish warning "Subject to change"
+This data is subject to a lot of changes, as there may be more data that needs to be added.
+```
+
+```typescript
+interface Output {
+    name: string;      /* The user's name. */
+    friends: string[]; /* The user's friends names, only if his friend list 
+                        * is public or friends only and the requesting user
+                        * is friends with the requested user. */
+}
+```
+
+#### Error codes
+
+- `1` : no user with this name was found or the requested user blocked the requesting user.
+
+#### HTTP codes
+
+- `400` : if the input is malformed (missing fields, unknown fields, etc.).
+- `401` : if no authorization token was provided or if the authorization token is invalid.
+
+## `GET` to `/user/find/{name}`
+
+Search for users by name.
+
+```admonish info
+Just like before, do not display users who blocked the requesting user.
+```
+
+### Input
+
+#### Headers
+
+- `Authorization: Bearer <token>`
+
+#### Data
+
+```typescript
+interface Url {
+    name: string;
+}
+```
+
+## `GET` to `/key`
+
+Get the public key that is used throughout the API.
+
+### Output
+
+#### Data
+
+```typescript
+interface Output {
+    key: string;
+}
+```

--- a/docs/book/src/api/database.md
+++ b/docs/book/src/api/database.md
@@ -1,0 +1,97 @@
+# Database layout
+
+Here is a preview of the database layout for the database.
+
+## `user_data`
+
+A table where the users are stored.
+
+```admonish info
+This is an extendable table, which means that it is easy to add fields if
+needed.
+```
+
+| Name       | Type      | Unique | Not null | Description                                   | Relation        |
+|------------|-----------|--------|----------|-----------------------------------------------|-----------------|
+| `user_id`  | `number`  | yes    | yes      | The ID of the user.                           | [`users`](../auth/database.md#users) on `id` |
+| `mature`   | `boolean` | no     | yes      | Whether the user wants to see mature content. |                 |
+| `birthday` | `date`    | no     | no       | The birthday of the user.                     |                 |
+
+## `friends`
+
+Stores friends relations.
+
+```admonish info
+You can deduce whether the friend request is accepted or not by checking if the
+date is null or not.
+```
+
+```admonish warning
+Entries in this table shall be unique. Meaning there should not be twice the
+same relation (not even swapped).
+```
+
+| Name            | Type     | Unique | Not null | Description                                        | Relation                                     |
+|-----------------|----------|--------|----------|----------------------------------------------------|----------------------------------------------|
+| `user_a`        | `number` | no     | yes      | The ID of one user.                                | [`users`](../auth/database.md#users) on `id` |
+| `user_b`        | `number` | no     | yes      | The ID of the other user.                          | [`users`](../auth/database.md#users) on `id` |
+| `date_accepted` | `date`   | no     | no       | The date at which the friend request was accepted. |                                              |
+
+## `history_user`
+
+The game history of the user.
+
+| Name      | Type     | Unique | Not null | Description         | Relation                                     |
+|-----------|----------|--------|----------|---------------------|----------------------------------------------|
+| `user`    | `number` | no     | yes      | The ID of the user. | [`users`](../auth/database.md#users) on `id` |
+| `game_id` | `number` | no     | yes      | The ID of the game. | [`history_game`](#history_game) on `id`      |
+
+## `history_game`
+
+The game history.
+
+| Name    | Type       | Unique | Not null | Description                                  | Relation |
+|---------|------------|--------|----------|----------------------------------------------|----------|
+| `id`    | `number`   | yes    | yes      | The ID of the game.                          |          |
+| `start` | `datetime` | no     | yes      | The date and time at which the game started. |          |
+| `end`   | `datetime` | no     | yes      | The date and time at which the game ended.   |          |
+| `public`| `boolean`  | no     | yes      | Whether the game was a public one or not.    |          |
+
+## `history_mini_game`
+
+The mini-game history.
+
+| Name      | Type       | Unique | Not null | Description                                       | Relation                                |
+|-----------|------------|--------|----------|---------------------------------------------------|-----------------------------------------|
+| `id`      | `number`   | yes    | yes      | The ID of the mini-game.                          |                                         |
+| `game_id` | `number`   | no     | yes      | The ID of the game.                               | [`history_game`](#history_game) on `id` |
+| `start`   | `datetime` | no     | yes      | The date and time at which the mini-game started. |                                         |
+| `end`     | `datetime` | no     | yes      | The date and time at which the mini-game ended.   |                                         |
+| `config`  | `json`     | no     | yes      | The configuration of the mini-game.               |                                         |
+
+## `history_mini_game_ranking`
+
+```admonish warning
+The entries should be unique, meaning that there shall not be two columns with
+the same `mini_game_id` and `user_id`.
+```
+
+The mini-game raking history.
+
+| Name           | Type     | Unique | Not null | Description            | Relation                                     |
+|----------------|----------|--------|----------|------------------------|----------------------------------------------|
+| `mini_game_id` | `number` | no     | yes      | The ID of the game.    | [`history_game`](#history_game) on `id`      |
+| `user_id`      | `number` | no     | yes      | The ID of the user.    | [`users`](../auth/database.md#users) on `id` |
+| `score`        | `number` | no     | yes      | The score of the user. |                                              |
+
+## `mini_games`
+
+Stores mini-games data. This table is to `projects` what `user_data` is to `users`.
+
+| Name          | Type      | Unique | Not null | Description                           | Relation                                           |
+|---------------|-----------|--------|----------|---------------------------------------|----------------------------------------------------|
+| `project_id`  | `number`  | yes    | yes      | The ID of the project.                | [`projects`](../auth/database.md#projects) on `id` |
+| `summary`     | `text`    | no     | yes      | A short description of the project.   |                                                    |
+| `description` | `text`    | no     | yes      | A long description of the project.    |                                                    |
+| `public`      | `boolean` | no     | yes      | Whether the project is public or not. |                                                    |
+

--- a/docs/book/src/api/database.md
+++ b/docs/book/src/api/database.md
@@ -11,11 +11,35 @@ This is an extendable table, which means that it is easy to add fields if
 needed.
 ```
 
-| Name       | Type      | Unique | Not null | Description                                   | Relation        |
-|------------|-----------|--------|----------|-----------------------------------------------|-----------------|
+| Name       | Type      | Unique | Not null | Description                                   | Relation                                     |
+|------------|-----------|--------|----------|-----------------------------------------------|----------------------------------------------|
 | `user_id`  | `number`  | yes    | yes      | The ID of the user.                           | [`users`](../auth/database.md#users) on `id` |
-| `mature`   | `boolean` | no     | yes      | Whether the user wants to see mature content. |                 |
-| `birthday` | `date`    | no     | no       | The birthday of the user.                     |                 |
+| `mature`   | `boolean` | no     | yes      | Whether the user wants to see mature content. |                                              |
+| `birthday` | `date`    | no     | no       | The birthday of the user.                     |                                              |
+
+## `user_settings`
+
+A table where the user settings are stored.
+
+```admonish info
+This is an extendable table, which means that it is easy to add fields if
+needed.
+```
+
+```admonish info "public_friend_list enum"
+`profile_visibility` and `friend_list_visibility`'s enum is composed of the
+following labels :
+
+- nobody
+- friends
+- everybody
+```
+
+| Name                     | Type                  | Unique | Not null | Description                     | Relation                                     |
+|--------------------------|-----------------------|--------|----------|---------------------------------|----------------------------------------------|
+| `user_id`                | `number`              | yes    | yes      | The ID of the user.             | [`users`](../auth/database.md#users) on `id` |
+| `profile_visibility`     | `enum` (`visibility`) | no     | yes      | Profile visibility setting.     |                                              |
+| `friend_list_visibility` | `enum` (`visibility`) | no     | yes      | Friend list visibility setting. |                                              |
 
 ## `friends`
 

--- a/docs/book/src/api/index.md
+++ b/docs/book/src/api/index.md
@@ -1,0 +1,14 @@
+# API service
+
+The API service is the "brain" of the project. It stores most data, like
+friends, history, etc. In this chapter, you will learn about it's structure and
+content.
+
+Here is a non-exhaustive list of what the API service does :
+
+- stores account data (personal preferences, profile picture, etc.)
+- stores friend lists
+- stores game history
+- displays available mini-games (soon to be marketplace)
+- creates lobbies
+- invites to lobbies

--- a/docs/book/src/architecture.md
+++ b/docs/book/src/architecture.md
@@ -56,6 +56,12 @@ The API service manages general user data, like friends, game history, high
 scores, added mini-games, etc. and it is also responsible for room creation. It
 relies on the authentication service to identify the user.
 
+```admonish info
+The API service and the Authentication service are actually the same server.
+They are described as two different parts of the project, but under the hood,
+they get compiled to the same binary.
+```
+
 ### Game server
 
 The game server is a real time socket server which communicates with the

--- a/docs/book/src/auth/api.md
+++ b/docs/book/src/auth/api.md
@@ -395,7 +395,7 @@ Decodes information encoded into a JWT and verifies its authenticity.
 Only authorized services should be able to decode and verify a JWT.
 ```
 
-```admonish note
+```admonish info
 This information can be cached, in order to not verify the JWT on each request.
 For example, when the API server wants to know if the JWT is valid, it will
 make a request to the authentication server, which will respond with the
@@ -404,7 +404,7 @@ API server won't have to make another request to the authentication server
 whenever the entity makes another request with the same JWT.
 ```
 
-```admonish note
+```admonish info
 Data could be decoded locally using a public key, but that implementation would
 make it difficult to invalidate tokens. This is why the service wanting to
 verify the token asks the authentication service if the token is valid or not.

--- a/docs/book/src/auth/database.md
+++ b/docs/book/src/auth/database.md
@@ -30,12 +30,12 @@ Entries must be removed after the expiration date has been reached.
 
 A table storing projects (mini-games).
 
-| Name      | Type     | Unique | Not null | Description                            | Relation        |
-|-----------|----------|--------|----------|----------------------------------------|-----------------|
-| `id`      | `number` | yes    | yes      | The ID of the project.                 |                 |
-| `name`    | `string` | no     | yes      | The name of the project.               |                 |
-| `api_key` | `string` | yes    | yes      | A key to authenticate the project.     |                 |
-| `user_id` | `number` | no     | yes      | The ID of the user owning the project. | `users` on `id` |
+| Name      | Type     | Unique | Not null | Description                            | Relation                  |
+|-----------|----------|--------|----------|----------------------------------------|---------------------------|
+| `id`      | `number` | yes    | yes      | The ID of the project.                 |                           |
+| `name`    | `string` | no     | yes      | The name of the project.               |                           |
+| `api_key` | `string` | yes    | yes      | A key to authenticate the project.     |                           |
+| `user_id` | `number` | no     | yes      | The ID of the user owning the project. | [`users`](#users) on `id` |
 
 ## `temp_users`
 


### PR DESCRIPTION
# VERY IMPORTANT, PLEASE READ

To make our lives easier, I think we should merge the API service and the authentication service. The book itself did not change a lot, it's only on the implementation side that things will change. Instead of making a new workspace for the API, everything should be included in the same workspace (probably the `api` folder). All API routes and authentication routes will be grouped in the same server, as well as the databases.